### PR TITLE
Fixed broken `ethstore` link in setup steps

### DIFF
--- a/Setup.md
+++ b/Setup.md
@@ -64,7 +64,7 @@ For Linux systems:
 
 To build Parity Ethereum from source follow the instructions in the [README](https://github.com/paritytech/parity-ethereum/blob/master/README.md).
 
-For Ethereum key management [Ethstore](https://github.com/paritytech/parity-ethereum/tree/master/ethstore) can be used. To compile it use
+For Ethereum key management [Ethstore](https://github.com/paritytech/parity-ethereum/tree/master/accounts/ethstore) can be used. To compile it use
 
 ```bash
 $ cargo build --release -p ethstore-cli


### PR DESCRIPTION
`ethstore` code has been moved into the `accounts` subdir